### PR TITLE
feat: add support for firefox/safari and other browsers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -155,12 +155,32 @@ function App() {
 
             const stream = canvas.captureStream(30) // 30 fps
 
-            const options: MediaRecorderOptions = {
-                mimeType: 'video/webm;codecs=vp9',
-                videoBitsPerSecond,
-            }
-
             try {
+                // Detect supported codec
+                // Safari support https://stackoverflow.com/a/66914924
+                // Firefox & Chrome https://stackoverflow.com/a/50881710
+                let mimeType: string | null = null
+                if (MediaRecorder.isTypeSupported('video/webm;codecs=vp9')) {
+                    mimeType = 'video/webm;codecs=vp9' // Chrome/chromium based
+                } else if (MediaRecorder.isTypeSupported('video/webm;codecs=vp8')) {
+                    mimeType = 'video/webm;codecs=vp8' // Firefox
+                } else if (MediaRecorder.isTypeSupported('video/mp4;codecs=avc1')) {
+                    mimeType = 'video/mp4;codecs=avc1' // Safari
+                } else if (MediaRecorder.isTypeSupported('video/webm')) {
+                    mimeType = 'video/webm' // fallback webm
+                } else if (MediaRecorder.isTypeSupported('video/mp4')) {
+                    mimeType = 'video/mp4' // fallback mp4
+                }
+
+                if (!mimeType) {
+                    throw new Error('No MediaRecorder supported video codec found on this browser')
+                }
+
+                const options: MediaRecorderOptions = {
+                    mimeType,
+                    videoBitsPerSecond,
+                }
+
                 const recorder = new MediaRecorder(stream, options)
                 recordedChunksRef.current = []
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import {
 } from './types/types'
 import CameraControls from './components/cameraControls'
 import { MdCancel } from 'react-icons/md'
+import { getSupportedMediaRecorderMimeType } from './utils/mediaRecorder'
 
 function App() {
     const DEFAULT_SETTIGNS: AsciiSettings = {
@@ -156,24 +157,9 @@ function App() {
             const stream = canvas.captureStream(30) // 30 fps
 
             try {
-                // Detect supported codec
-                // Safari support https://stackoverflow.com/a/66914924
-                // Firefox & Chrome https://stackoverflow.com/a/50881710
-                let mimeType: string | null = null
-                if (MediaRecorder.isTypeSupported('video/webm;codecs=vp9')) {
-                    mimeType = 'video/webm;codecs=vp9' // Chrome/chromium based
-                } else if (MediaRecorder.isTypeSupported('video/webm;codecs=vp8')) {
-                    mimeType = 'video/webm;codecs=vp8' // Firefox
-                } else if (MediaRecorder.isTypeSupported('video/mp4;codecs=avc1')) {
-                    mimeType = 'video/mp4;codecs=avc1' // Safari
-                } else if (MediaRecorder.isTypeSupported('video/webm')) {
-                    mimeType = 'video/webm' // fallback webm
-                } else if (MediaRecorder.isTypeSupported('video/mp4')) {
-                    mimeType = 'video/mp4' // fallback mp4
-                }
-
+                const mimeType = getSupportedMediaRecorderMimeType()
                 if (!mimeType) {
-                    throw new Error('No MediaRecorder supported video codec found on this browser')
+                    throw new Error('No supported video codec found')
                 }
 
                 const options: MediaRecorderOptions = {

--- a/src/utils/mediaRecorder.ts
+++ b/src/utils/mediaRecorder.ts
@@ -1,0 +1,23 @@
+/**
+ * Gets the first supported MIME type for MediaRecorder
+ * Falls back through multiple codec options for cross-browser compatibility
+ * Safari support https://stackoverflow.com/a/66914924
+ * Firefox & Chrome https://stackoverflow.com/a/50881710
+ */
+export function getSupportedMediaRecorderMimeType(): string | undefined {
+    const mimeTypes = [
+        'video/webm;codecs=vp9', // Chrome/chromium based
+        'video/webm;codecs=vp8', // Firefox
+        'video/mp4;codecs=avc1', // Safari
+        'video/webm', // fallback webm
+        'video/mp4', // fallback mp4
+    ]
+
+    for (const mimeType of mimeTypes) {
+        if (MediaRecorder.isTypeSupported(mimeType)) {
+            return mimeType
+        }
+    }
+
+    return undefined
+}


### PR DESCRIPTION
Firefox was failing to record before this change.

I've tested that Chrome still uses vp9 and firefox vp8

Safari and others support should be fine, but not tested